### PR TITLE
Fix install command instruction

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -75,7 +75,7 @@
 </div>
 
 <p>To enable the <code>git</code> aliases:</p>
-<pre><span class=ig>$ </span>legit install</pre>
+<pre><span class=ig>$ </span>legit --install</pre>
 
 
 <p>Nice and simple — the way it should be.</p>


### PR DESCRIPTION
The `install` subcommand doesn't exist - it should be the `--install` flag.